### PR TITLE
Solve thread deletion issues

### DIFF
--- a/bridge/discord/handlers.go
+++ b/bridge/discord/handlers.go
@@ -26,6 +26,16 @@ func (b *Bdiscord) messageDelete(s *discordgo.Session, m *discordgo.MessageDelet
 		return
 	}
 	rmsg := config.Message{Account: b.Account, ID: m.ID, Event: config.EventMsgDelete, Text: config.EventMsgDelete}
+	//lookup our channel ID using the API. If its a thread, we need to get the parent channel ID and set m.ChannelID to that.
+	PotentialThread, err := s.Channel(m.ChannelID)
+	//print  PotentialThread
+	if err != nil {
+		b.Log.Debugf("Error getting channel info for %s: %v", m.ChannelID, err)
+		return
+	}
+	if PotentialThread.ParentID != "" && PotentialThread.IsThread() {
+		m.ChannelID = PotentialThread.ParentID
+	}
 	rmsg.Channel = b.getChannelName(m.ChannelID)
 
 	b.Log.Debugf("<= Sending message from %s to gateway", b.Account)


### PR DESCRIPTION
Added code to track Slack messages over the bridge to delete on the Discord side, as these messages didn't have a parentID anymore.

Added code to replace the ChannelID on the discord side with the Parent ID of the thread, to allow deletion on the slack side as replies are always in the parent, never in a seperate channel.